### PR TITLE
Add ship and grid models

### DIFF
--- a/lib/battleship.rb
+++ b/lib/battleship.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "battleship/version"
+require_relative "battleship/grid"
 require_relative "battleship/cell"
 require_relative "battleship/ship"
 

--- a/lib/battleship.rb
+++ b/lib/battleship.rb
@@ -2,6 +2,7 @@
 
 require_relative "battleship/version"
 require_relative "battleship/cell"
+require_relative "battleship/ship"
 
 module Battleship
   class Error < StandardError; end

--- a/lib/battleship/grid.rb
+++ b/lib/battleship/grid.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Battleship
+  class Grid
+    GRID_SIZE = 5
+
+    attr_reader :cells
+
+    def initialize
+      @cells = Array.new(GRID_SIZE) { Array.new(GRID_SIZE) { Cell.new } }
+    end
+
+    def place_ship(ship)
+      coordinates = calculate_coordinates(ship)
+      check_out_of_bounds(coordinates)
+      check_valid_placement(coordinates)
+
+      coordinates.each { |row, col| @cells[row][col].place_ship_unit }
+    end
+
+    def attack(coordinate)
+      row, col = parse_coordinates(coordinate)
+      @cells[row][col].hit
+    end
+
+    def calculate_coordinates(ship)
+      row, col = parse_coordinates(ship.start_coordinate)
+      coordinates = []
+
+      if ship.orientation == :horizontal
+        ship.size.times { |i| coordinates << [row, col + i] } 
+      elsif ship.orientation == :vertical
+        ship.size.times { |i| coordinates << [row + i, col] }
+      end
+
+      coordinates
+    end
+
+    private
+
+    def parse_coordinates(coordinate)
+      col = coordinate[0].ord - "A".ord
+      row = coordinate[1..-1].to_i - 1
+
+      [row, col]
+    end
+
+    def check_out_of_bounds(coordinates)      
+      return if coordinates.all? { |row, col| row.between?(0, GRID_SIZE - 1) && col.between?(0, GRID_SIZE - 1) }
+      
+      raise ArgumentError, "Ship outside grid"
+    end
+
+    def check_valid_placement(coordinates)
+      return if coordinates.all? { |row, col| @cells[row][col].state == :water }
+
+      raise ArgumentError, "Ship on top of another ship"
+    end
+  end
+end

--- a/lib/battleship/ship.rb
+++ b/lib/battleship/ship.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Battleship
+  class Ship
+    attr_reader :size, :hp, :orientation, :start_coordinate
+
+    def initialize(size, start_coordinate, orientation)
+      @size = size
+      @hp = size
+      @start_coordinate = start_coordinate
+      @orientation = orientation
+    end
+
+    def hit
+      raise RuntimeError, "Ship already sunk" if sunk?
+      
+      @hp -= 1
+      sunk?
+    end
+
+    def sunk?
+      @hp.zero?
+    end
+  end
+end

--- a/spec/lib/battleship/grid_spec.rb
+++ b/spec/lib/battleship/grid_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Battleship
+  RSpec.describe Grid do
+    let(:grid) { described_class.new }
+    let(:start_coordinate) { "A1" }
+    let(:orientation) { :horizontal }
+    let(:ship) { Ship.new(3, start_coordinate, orientation) }
+
+    describe "#initialize" do
+      it "creates a grid with default size of 5x5" do
+        expect(grid.cells.size).to eq 5
+        expect(grid.cells.all? { |row| row.size == 5 }).to eq true
+      end
+    end
+
+    describe "#place_ship" do
+      context "when ship is placed horizontally" do
+        let (:orientation) { :horizontal }
+
+        it "places the ship on the grid" do
+          grid.place_ship(ship)
+
+          expect(grid.cells[0][0].state).to eq :ship
+          expect(grid.cells[0][1].state).to eq :ship
+          expect(grid.cells[0][2].state).to eq :ship
+        end
+      end
+
+      context "when ship is placed vertically" do
+        let (:orientation) { :vertical }
+
+        it "places the ship on the grid" do
+          grid.place_ship(ship)
+
+          expect(grid.cells[0][0].state).to eq :ship
+          expect(grid.cells[1][0].state).to eq :ship
+          expect(grid.cells[2][0].state).to eq :ship
+        end
+      end
+
+      context "when ship is out of bounds" do
+        let(:ship) { Ship.new(5, "E1", :horizontal) }
+
+        it "raises an error" do
+          expect { grid.place_ship(ship) }.to raise_error(ArgumentError, "Ship outside grid")
+        end
+      end
+
+      context "when ship is on top of another ship" do
+        it "raises an error" do
+          grid.place_ship(ship)
+
+          expect { grid.place_ship(ship) }.to raise_error(ArgumentError, "Ship on top of another ship")
+        end
+      end
+    end
+
+    describe "#attack" do
+      context "when attack hits a ship" do
+        it "returns true" do
+          grid.place_ship(ship)
+
+          expect(grid.attack("A1")).to eq true
+        end
+
+        it "changes the state of the cell to hit" do
+          grid.place_ship(ship)
+          grid.attack("A1")
+
+          expect(grid.cells[0][0].state).to eq :hit
+        end
+      end
+
+      context "when attack misses a ship" do
+        it "returns false" do
+          expect(grid.attack("A1")).to eq false
+        end
+
+        it "changes the state of the cell to miss" do
+          grid.attack("A1")
+
+          expect(grid.cells[0][0].state).to eq :miss
+        end
+      end
+    end
+
+    describe "#calculate_coordinates" do
+      context "when ship is placed horizontally" do
+        let(:orientation) { :horizontal }
+
+        it "returns expected array of coordinates" do
+          expect(grid.calculate_coordinates(ship)).to eq [[0, 0], [0, 1], [0, 2]]
+        end
+      end
+
+      context "when ship is placed vertically" do
+        let(:orientation) { :vertical }
+
+        it "returns expected array of coordinates" do
+          expect(grid.calculate_coordinates(ship)).to eq [[0, 0], [1, 0], [2, 0]]
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/battleship/ship_spec.rb
+++ b/spec/lib/battleship/ship_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Battleship
+  RSpec.describe Ship do
+    let(:ship) { described_class.new(3, "A5", :horizontal) }
+
+    describe "#initialize" do
+      it "has a size" do
+        expect(ship.size).to eq 3
+      end
+
+      it "has hp equal to size" do
+        expect(ship.hp).to eq 3
+      end
+
+      it "has a start coordinate" do
+        expect(ship.start_coordinate).to eq "A5"
+      end
+
+      it "has an orientation" do
+        expect(ship.orientation).to eq :horizontal
+      end
+    end
+
+    describe "#hit" do
+      context "when ship is not sunk" do
+        it "decreases hp by 1" do
+          ship.hit
+
+          expect(ship.hp).to eq 2
+        end
+
+        it "returns false" do
+          expect(ship.hit).to eq false
+        end
+      end
+
+      context "when ship is sunk" do
+        let(:ship) { described_class.new(1, "A1", :horizontal) }
+
+        before do
+          ship.hit
+        end
+
+        it "raises an error" do
+          expect { ship.hit }.to raise_error(RuntimeError, "Ship already sunk")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

- lib/battleship.rb: Added requires for battleship/grid and battleship/ship.
- lib/battleship/grid.rb: Introduced a new Grid class to manage the game grid, with methods to place ships and handle attacks.
- lib/battleship/ship.rb: Introduced a new Ship class to represent ships, including their size, health points, and orientation.
